### PR TITLE
ADD : Feature/token - refreshToken을 이용한 accessToken관리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^13.5.0",
+        "@types/js-cookie": "^3.0.3",
         "@types/node": "^16.18.11",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.10",
@@ -4873,6 +4874,11 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.3.tgz",
+      "integrity": "sha512-Xe7IImK09HP1sv2M/aI+48a20VX+TdRJucfq4vfRVy6nWN8PYPOEnlMRSgxJAgYQIXJVL8dZ4/ilAM7dWNaOww=="
     },
     "node_modules/@types/js-levenshtein": {
       "version": "1.1.1",
@@ -27848,6 +27854,11 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
+    },
+    "@types/js-cookie": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.3.tgz",
+      "integrity": "sha512-Xe7IImK09HP1sv2M/aI+48a20VX+TdRJucfq4vfRVy6nWN8PYPOEnlMRSgxJAgYQIXJVL8dZ4/ilAM7dWNaOww=="
     },
     "@types/js-levenshtein": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
+    "@types/js-cookie": "^3.0.3",
     "@types/node": "^16.18.11",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",

--- a/src/atom.tsx
+++ b/src/atom.tsx
@@ -25,10 +25,16 @@ const commentOption = atom({
   default: 0,
 });
 
+const accessToken = atom({
+  key: 'accecssToken',
+  default: '',
+});
+
 export {
   categoryState,
   articleSearchOption,
   articleSearchKeyword,
   currentPage,
   commentOption,
+  accessToken,
 };

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -1,10 +1,15 @@
 import React, { useState } from 'react';
+import Cookies from 'js-cookie';
 import { Link, NavLink } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { accessToken } from '../../atom';
 import Login from '../../pages/login/Login';
 import Search from '../search/Search';
 import './Nav.scss';
 
 function Nav() {
+  const [token, setAccessToken] = useRecoilState(accessToken);
+
   const [activeLogin, setActivelogin] = useState(false);
 
   const handleLogin = (): void => {
@@ -18,7 +23,10 @@ function Nav() {
 
   const logOut = (): void => {
     alert('로그아웃 되었습니다!');
-    localStorage.removeItem('token');
+    // localStorage.removeItem('token');
+    Cookies.remove('refreshToken');
+    setAccessToken('');
+
     localStorage.removeItem('userName');
     window.location.reload();
   };
@@ -32,7 +40,7 @@ function Nav() {
   return (
     <header className="allNav">
       <nav className="subNav">
-        {localStorage.getItem('token') ? (
+        {token !== '' ? (
           <section className="subTabWrap">
             <NavLink
               className="subTab"

--- a/src/customApi.tsx
+++ b/src/customApi.tsx
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import { BASE_URL } from './config';
+import { refresh, refreshRemove } from './refresh';
+
+const Api = axios.create({
+  baseURL: BASE_URL,
+  timeout: 10000,
+  params: {},
+});
+
+Api.interceptors.request.use(refresh, refreshRemove);
+
+export default Api;

--- a/src/pages/login/GithubLogin.tsx
+++ b/src/pages/login/GithubLogin.tsx
@@ -3,11 +3,14 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import './GithubLogin.scss';
 import { BASE_URL } from '../../config';
+import { useSetRecoilState } from 'recoil';
+import { accessToken } from '../../atom';
 
 function GithubLogin() {
   const navigate = useNavigate();
   const location = useLocation();
   const GITHUB_CODE: string = location.search.split('=')[1];
+  const setAccessToken = useSetRecoilState(accessToken);
 
   useEffect(() => {
     axios
@@ -15,7 +18,8 @@ function GithubLogin() {
       .then(res => {
         localStorage.setItem('userName', res.data.userName);
         if (res.data.isMember) {
-          localStorage.setItem('token', res.data.accessToken);
+          // localStorage.setItem('token', res.data.accessToken);
+          setAccessToken(res.data.accessToken);
           window.location.href = localStorage.getItem('referrer') as string;
           localStorage.removeItem('referrer');
         } else {

--- a/src/pages/login/Signup.tsx
+++ b/src/pages/login/Signup.tsx
@@ -5,6 +5,8 @@ import Form from 'react-bootstrap/Form';
 import { BASE_URL } from '../../config';
 import { CategoryType, SignupUserType } from '../../../@types/Account';
 import './Signup.scss';
+import { accessToken } from '../../atom';
+import { useSetRecoilState } from 'recoil';
 
 function Signup(): JSX.Element {
   const navigate = useNavigate();
@@ -14,6 +16,8 @@ function Signup(): JSX.Element {
     fieldId: 0,
     careerId: 0,
   });
+  const setAccessToken = useSetRecoilState(accessToken);
+
   useEffect(() => {
     if (
       !localStorage.getItem('githubId') &&
@@ -49,7 +53,8 @@ function Signup(): JSX.Element {
             throw new Error('회원가입에 실패하였습니다.');
           } else {
             alert('회원가입에 성공하였습니다!');
-            localStorage.setItem('token', res.data.accessToken);
+            // localStorage.setItem('token', res.data.accessToken);
+            setAccessToken(res.data.accessToken);
             localStorage.removeItem('githubId');
             window.location.href = localStorage.getItem('referrer') as string;
             localStorage.removeItem('referrer');

--- a/src/refresh.tsx
+++ b/src/refresh.tsx
@@ -1,9 +1,9 @@
 import axios, { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
-import Cookie from 'js-cookie';
+import Cookies from 'js-cookie';
 import { BASE_URL } from './config';
 
 const refresh = async (config: any): Promise<any> => {
-  const refreshToken = Cookie.get('refreshToken');
+  const refreshToken = Cookies.get('refreshToken');
   let token = localStorage.getItem('accessToken');
 
   // 토큰이 만료되었고, refreshToken 이 저장되어 있을 때
@@ -27,7 +27,7 @@ const refresh = async (config: any): Promise<any> => {
 };
 
 const refreshRemove = (err: any) => {
-  Cookie.remove('refreshToken');
+  Cookies.remove('refreshToken');
 };
 
 export { refresh, refreshRemove };

--- a/src/refresh.tsx
+++ b/src/refresh.tsx
@@ -1,0 +1,41 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import Cookie from 'js-cookie';
+import moment from 'moment';
+import { BASE_URL } from './config';
+
+const refresh = async (
+  config: AxiosRequestConfig
+): Promise<AxiosRequestConfig> => {
+  const refreshToken = Cookie.get('refreshToken');
+  const expireAt = localStorage.getItem('expiresAt');
+  let token = localStorage.getItem('accessToken');
+
+  // 토큰이 만료되었고, refreshToken 이 저장되어 있을 때
+  if (moment(expireAt).diff(moment()) < 0 && refreshToken) {
+    const body = {
+      refreshToken,
+    };
+
+    // 토큰 갱신 서버통신
+    const { data } = await axios.post(`${BASE_URL}/auth`, body);
+
+    token = data.data.accessToken;
+    localStorage.setItem('accessToken', data.data.accessToken);
+    localStorage.setItem(
+      'expiresAt',
+      moment().add(1, 'hour').format('yyyy-MM-DD HH:mm:ss')
+    );
+  }
+
+  config.headers = {
+    Authorization: `Bearer ${token}`,
+  };
+
+  return config;
+};
+
+const refreshErrorHandle = (err: any) => {
+  Cookie.remove('refreshToken');
+};
+
+export { refresh, refreshErrorHandle };

--- a/src/refresh.tsx
+++ b/src/refresh.tsx
@@ -1,17 +1,13 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
 import Cookie from 'js-cookie';
-import moment from 'moment';
 import { BASE_URL } from './config';
 
-const refresh = async (
-  config: AxiosRequestConfig
-): Promise<AxiosRequestConfig> => {
+const refresh = async (config: any): Promise<any> => {
   const refreshToken = Cookie.get('refreshToken');
-  const expireAt = localStorage.getItem('expiresAt');
   let token = localStorage.getItem('accessToken');
 
   // 토큰이 만료되었고, refreshToken 이 저장되어 있을 때
-  if (moment(expireAt).diff(moment()) < 0 && refreshToken) {
+  if (refreshToken) {
     const body = {
       refreshToken,
     };
@@ -21,10 +17,6 @@ const refresh = async (
 
     token = data.data.accessToken;
     localStorage.setItem('accessToken', data.data.accessToken);
-    localStorage.setItem(
-      'expiresAt',
-      moment().add(1, 'hour').format('yyyy-MM-DD HH:mm:ss')
-    );
   }
 
   config.headers = {
@@ -34,8 +26,8 @@ const refresh = async (
   return config;
 };
 
-const refreshErrorHandle = (err: any) => {
+const refreshRemove = (err: any) => {
   Cookie.remove('refreshToken');
 };
 
-export { refresh, refreshErrorHandle };
+export { refresh, refreshRemove };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
* refreshToken을 이용한 accessToken관리

- <br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
작업 진행사항
* refreshToken이용하여 accessToken 재발급받는 함수 작성 (/src/refresh.tsx)
* 위에서 작성한 함수를 axios실행전 먼저실행하도록 하는 interceptor 로 만들어주는 코드 작성(/src/customApi.tsx)
* 로그인시 받은 에세스토큰 리코일로저장하는 코드작성완료 (atom.tsx수정, githubLogin.tsx수정)
* 회원가입하고난 뒤 받은 토큰 리코일로저장(Signup.tsx수정)
* 네비바에서 로그아웃시 쿠키에서 리프레쉬토큰삭제, 에세스토큰’’로 저장 (Nav.tsx 수정)
* 네비바에서 accessToken값이 ‘’ 이면 로그아웃상태로 간주하는 코드로 수정 (Nav.tsx 수정)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

-

<br />

## :: 기타 질문 및 특이 사항
